### PR TITLE
Force bash as SHELL in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL = /bin/bash
 #TOOLPREFIX=i386-elf-
 ifndef TOOLPREFIX
 TOOLPREFIX := $(shell if i386-elf-objdump -i 2>&1 | grep '^elf32-i386$$' >/dev/null 2>&1; \


### PR DESCRIPTION
Go compiler version check fails on debian where default shell is not bash.

```
$ make
/bin/sh: 1: [[: not found
GOOS=linux GOARCH=386 go build -o kernel.elf -tags "nes sshd" -ldflags '-E github.com/icexin/eggos/kernel.rt0 -T 0x100000' ./kmain
[...]
```

Forcing bash should fix this (and possibly other) bash specific test.