### PR TITLE
Call various kernel inits directly, rather than via an import

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -14,3 +14,11 @@ Nope. You can install [multiple versions](https://go.dev/doc/manage-install#inst
 ```bash
 $ GOROOT=$(go1.16.13 env GOROOT) egg build
 ```
+
+### How do I disable mouse/ network/ filesystem support?
+
+By default, running `egg build` will transparently load a set of well tested, useful drivers and kernel components into your application by generating an init function which configures things.
+
+This works wonderfully for turning any application into a useful, and usable, unikernel but is not without drawbacks- especially where things like mice, or filesystem support is not needed.
+
+You can run `egg generate` at the root of your project and then edit the file `zz_load_eggos.go` accordingly. The presence of this file will stop `egg build` generating anything its self.

--- a/cmd/egg/build/patch.go
+++ b/cmd/egg/build/patch.go
@@ -3,27 +3,19 @@ package build
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"text/template"
+
+	"github.com/icexin/eggos/cmd/egg/generate"
 )
 
 const (
 	eggosModulePath = "github.com/icexin/eggos"
-	eggosImportFile = "import_eggos.go"
 	overlayFile     = "overlay.json"
-)
-
-var (
-	eggosImportTpl = template.Must(template.New("eggos").Parse(`
-	//+build eggos
-
-	package {{.name}}
-	import _ "github.com/icexin/eggos"
-	`))
 )
 
 type gomodule struct {
@@ -45,16 +37,27 @@ type buildOverlay struct {
 }
 
 func (b *Builder) eggosImportFile() string {
-	return filepath.Join(b.basedir, eggosImportFile)
+	return filepath.Join(b.basedir, generate.ImportFile)
+}
+
+func (b Builder) localImportFileExists() bool {
+	_, err := os.Stat(generate.ImportFile)
+	if err == nil {
+		return true
+	}
+
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+
+	panic(err)
 }
 
 func (b *Builder) overlayFile() string {
 	return filepath.Join(b.basedir, overlayFile)
 }
 
-func (b *Builder) buildPrepare() error {
-	var err error
-
+func (b *Builder) buildPrepare() (err error) {
 	if !b.modHasEggos() {
 		log.Printf("eggos not found in go.mod")
 		err = b.editGoMod()
@@ -63,12 +66,16 @@ func (b *Builder) buildPrepare() error {
 		}
 	}
 
-	err = b.writeImportFile(b.eggosImportFile())
+	if b.localImportFileExists() {
+		return
+	}
+
+	err = b.writeImportFile()
 	if err != nil {
 		return err
 	}
 
-	err = writeOverlayFile(b.overlayFile(), eggosImportFile, b.eggosImportFile())
+	err = writeOverlayFile(b.overlayFile(), generate.ImportFile, b.eggosImportFile())
 	if err != nil {
 		return err
 	}
@@ -87,7 +94,7 @@ func writeOverlayFile(overlayFile, dest, source string) error {
 
 func (b *Builder) readGomodule() (*gomodule, error) {
 	var buf bytes.Buffer
-	cmd := exec.Command(b.gobin(), "mod", "edit", "-json")
+	cmd := exec.Command(b.gobin, "mod", "edit", "-json")
 	cmd.Stdout = &buf
 	err := cmd.Run()
 	if err != nil {
@@ -129,23 +136,15 @@ func (b *Builder) editGoMod() error {
 		"GOARCH=amd64",
 	}
 	env = append(env, os.Environ()...)
-	cmd := exec.Command(b.gobin(), "get", getPath)
+	cmd := exec.Command(b.gobin, "get", getPath)
 	cmd.Env = env
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
-func (b *Builder) currentPkgName() string {
-	out, err := exec.Command(b.gobin(), "list", "-f", `{{.Name}}`).CombinedOutput()
-	if err != nil {
-		log.Panicf("get current package name:%s", out)
-	}
-	return strings.TrimSpace(string(out))
-}
-
 func (b *Builder) currentModulePath() string {
-	out, err := exec.Command(b.gobin(), "list", "-f", `{{.Module.Path}}`).CombinedOutput()
+	out, err := exec.Command(b.gobin, "list", "-f", `{{.Module.Path}}`).CombinedOutput()
 	if err != nil {
 		log.Panicf("get current module path:%s", out)
 	}
@@ -153,16 +152,11 @@ func (b *Builder) currentModulePath() string {
 
 }
 
-func (b *Builder) writeImportFile(fname string) error {
-	pkgname := b.currentPkgName()
-	var rawFile bytes.Buffer
-	err := eggosImportTpl.Execute(&rawFile, map[string]interface{}{
-		"name": pkgname,
-	})
+func (b *Builder) writeImportFile() (err error) {
+	g, err := generate.NewGenerator(b.basedir)
 	if err != nil {
-		return err
+		return
 	}
 
-	err = os.WriteFile(fname, rawFile.Bytes(), 0644)
-	return err
+	return g.Generate()
 }

--- a/cmd/egg/cmd/build.go
+++ b/cmd/egg/cmd/build.go
@@ -22,10 +22,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	output string
-)
-
 // buildCmd represents the build command
 var buildCmd = &cobra.Command{
 	Use:                "build",

--- a/cmd/egg/cmd/generate.go
+++ b/cmd/egg/cmd/generate.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"log"
+	"os"
+
+	"github.com/icexin/eggos/cmd/egg/generate"
+	"github.com/spf13/cobra"
+)
+
+// generateCmd represents the generate command
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "generate an eggos loader file in this project",
+	Long: `generate the zz_load_eggos.go file in this projetc directly
+in order to affect the components which are built into the unikernel.
+
+Should this file not exist, running 'egg build' will generate a temporary one.`,
+	Run: func(*cobra.Command, []string) {
+		err := runGenerate()
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func runGenerate() (err error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+
+	g, err := generate.NewGenerator(wd)
+	if err != nil {
+		return
+	}
+
+	return g.Generate()
+}
+
+func init() {
+	rootCmd.AddCommand(generateCmd)
+}

--- a/cmd/egg/cmd/run.go
+++ b/cmd/egg/cmd/run.go
@@ -122,15 +122,6 @@ func runKernel(args []string) error {
 	}
 }
 
-func fileExists(name string) bool {
-	if _, err := os.Stat(name); err != nil {
-		if os.IsNotExist(err) {
-			return false
-		}
-	}
-	return true
-}
-
 func mustLoaderFile(fname string) {
 	content, err := assets.Boot.ReadFile("boot/multiboot.elf")
 	if err != nil {

--- a/cmd/egg/generate/generate.go
+++ b/cmd/egg/generate/generate.go
@@ -1,0 +1,62 @@
+package generate
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/icexin/eggos/cmd/egg/util"
+)
+
+const (
+	ImportFile = "zz_load_eggos.go"
+)
+
+type Generator struct {
+	gobin   string
+	basedir string
+}
+
+func NewGenerator(basedir string) (g Generator, err error) {
+	g = Generator{
+		gobin:   util.GoBin(),
+		basedir: basedir,
+	}
+
+	return
+}
+
+func (g Generator) Generate() error {
+	return g.writeImportFile(g.eggosImportFile())
+}
+
+func (g *Generator) eggosImportFile() string {
+	return filepath.Join(g.basedir, ImportFile)
+}
+
+func (b *Generator) currentPkgName() string {
+	out, err := exec.Command(b.gobin, "list", "-f", `{{.Name}}`).CombinedOutput()
+	if err != nil {
+		log.Panicf("get current package name:%s", out)
+	}
+
+	return strings.TrimSpace(string(out))
+}
+
+func (g *Generator) writeImportFile(fname string) error {
+	pkgname := g.currentPkgName()
+	var rawFile bytes.Buffer
+
+	err := eggosImportTpl.Execute(&rawFile, map[string]interface{}{
+		"name": pkgname,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(fname, rawFile.Bytes(), 0644)
+}

--- a/cmd/egg/generate/template.go
+++ b/cmd/egg/generate/template.go
@@ -1,0 +1,49 @@
+package generate
+
+import (
+	"text/template"
+)
+
+var (
+	eggosImportTpl = template.Must(template.New("eggos").Parse(`//+build eggos
+package {{.name}}
+
+import (
+	"runtime"
+
+	"github.com/icexin/eggos/console"
+	"github.com/icexin/eggos/drivers/cga/fbcga"
+	_ "github.com/icexin/eggos/drivers/e1000"
+	"github.com/icexin/eggos/drivers/kbd"
+	"github.com/icexin/eggos/drivers/pci"
+	"github.com/icexin/eggos/drivers/ps2/mouse"
+	"github.com/icexin/eggos/drivers/uart"
+	"github.com/icexin/eggos/drivers/vbe"
+	"github.com/icexin/eggos/fs"
+	"github.com/icexin/eggos/inet"
+	"github.com/icexin/eggos/kernel"
+)
+
+func kernelInit() {
+	// trap and syscall threads use two Ps,
+	// and the remainings are for other goroutines
+	runtime.GOMAXPROCS(6)
+
+	kernel.Init()
+	uart.Init()
+	kbd.Init()
+	mouse.Init()
+	console.Init()
+
+	fs.Init()
+	vbe.Init()
+	fbcga.Init()
+	pci.Init()
+	inet.Init()
+}
+
+func init() {
+	kernelInit()
+}
+`))
+)

--- a/cmd/egg/util/util.go
+++ b/cmd/egg/util/util.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func GoBin() string {
+	gr, ok := os.LookupEnv("GOROOT")
+	if !ok {
+		return "go"
+	}
+
+	return filepath.Join(gr, "bin", "go")
+}


### PR DESCRIPTION
See: https://github.com/icexin/eggos/issues/98

Because of the way go loads init functions from packages, any steps which must occur before kernel init (setting loglevels, perhaps) requires a bit of hacking.

By generating these calls as a first class init function for a given unikernel we can avoid having to hack around the golang init function loader.

This change adds a generate command to egg, which can be to allow developers to maintain their own eggos include file to allow for developers to change how their unikernel is run, such as being able to change the value of GOMAXPROCS, or disable networking.

The build command now checks for the presence of this file. If it does not exist then the build command will use the current method of generating a file and overlay. Otherwise it uses the user specified file.

Finally, the file we generate is prefixed with `zz_` to try and influence when the file loads, in order to let user specified init functions (like setting log levels) to run first